### PR TITLE
Updates to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,6 @@ RUN apt-get update && \
     apt-get install -y libpq5 libpq-dev postgresql-client postgresql-client-common
 RUN pip install awscli
 
-# Update the protmapper
-RUN pip install -U git+https://github.com/indralab/protmapper.git && \
-    python -m protmapper.resources
-
 # Install psycopg2
 RUN git clone https://github.com/psycopg/psycopg2.git && \
     cd psycopg2 && \
@@ -32,9 +28,6 @@ RUN git clone https://github.com/psycopg/psycopg2.git && \
 RUN git clone https://github.com/pagreene/pgcopy.git && \
     cd pgcopy && \
     python setup.py install
-
-# Install adeft
-RUN python -m adeft.download
 
 # Install covid-19
 RUN git clone https://github.com/indralab/covid-19.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN git clone https://github.com/indralab/covid-19.git
 # Install indra_db
 RUN git clone https://github.com/indralab/indra_db.git && \
     cd indra_db && \
-    pip install -e . && \
+    pip install -e .[all] && \
     pip list && \
     echo "PYTHONPATH =" $PYTHONPATH && \
     git checkout $BUILD_BRANCH && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && \
 RUN pip install awscli
 
 # Update the protmapper
-RUN pip install -U git+https://github.com/indralab/protmapper.git
+RUN pip install -U git+https://github.com/indralab/protmapper.git && \
+    python -m protmapper.resources
 
 # Install psycopg2
 RUN git clone https://github.com/psycopg/psycopg2.git && \
@@ -33,11 +34,7 @@ RUN git clone https://github.com/pagreene/pgcopy.git && \
     python setup.py install
 
 # Install adeft
-RUN pip install adeft
 RUN python -m adeft.download
-
-# Install gilda
-RUN pip install gilda
 
 # Install covid-19
 RUN git clone https://github.com/indralab/covid-19.git


### PR DESCRIPTION
This PR makes the following changes:
- Remove redundant installs and updates to gilda, adeft and protmapper that can be done at the indra_docker level (no longer have to do an indra_deps_docker build)
- Make sure extra dependencies like termcolor, cachetools, etc. are installed in the image